### PR TITLE
Add support for domain translation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,3 +34,6 @@ jobs:
               run: composer run phpunit
             - name: Send coverage
               uses: codecov/codecov-action@v1
+              with:
+                flags: unit-${{ matrix.php-version }}-${{ matrix.os }}
+                name: phpunit-${{ matrix.php-version }}-${{ matrix.os }}

--- a/src/I18nExtension.php
+++ b/src/I18nExtension.php
@@ -15,6 +15,8 @@ namespace PhpMyAdmin\Twig\Extensions;
 use PhpMyAdmin\Twig\Extensions\TokenParser\TransTokenParser;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
+use function gettext;
+use function dgettext;
 
 class I18nExtension extends AbstractExtension
 {
@@ -32,7 +34,7 @@ class I18nExtension extends AbstractExtension
     public function getFilters()
     {
         return [
-            new TwigFilter('trans', 'gettext'),
+            new TwigFilter('trans', '\PhpMyAdmin\Twig\Extensions\I18nExtension::translate'), /* Note, the filter does not handle plurals */
         ];
     }
 
@@ -44,5 +46,22 @@ class I18nExtension extends AbstractExtension
     public function getName()
     {
         return 'i18n';
+    }
+
+    /**
+     * Translate a GetText string via filter
+     *
+     * @param string      $message The message to translate
+     * @param string|null $domain  The GetText domain
+     */
+    public static function translate(string $message, ?string $domain = null): string
+    {
+        /* If we don't have a domain, assume we're just using the default */
+        if ($domain === null) {
+            return gettext($message);
+        }
+
+        /* Otherwise specify where the message comes from */
+        return dgettext($domain, $message);
     }
 }

--- a/src/I18nExtension.php
+++ b/src/I18nExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of Twig.
+ * This file is part of Twig I18n extension.
  *
  * (c) 2010-2019 Fabien Potencier
  * (c) 2019-2021 phpMyAdmin contributors
@@ -34,7 +34,7 @@ class I18nExtension extends AbstractExtension
     public function getFilters()
     {
         return [
-            new TwigFilter('trans', '\PhpMyAdmin\Twig\Extensions\I18nExtension::translate'), /* Note, the filter does not handle plurals */
+            new TwigFilter('trans', [$this, 'translate']), /* Note, the filter does not handle plurals */
         ];
     }
 
@@ -54,7 +54,7 @@ class I18nExtension extends AbstractExtension
      * @param string      $message The message to translate
      * @param string|null $domain  The GetText domain
      */
-    public static function translate(string $message, ?string $domain = null): string
+    public function translate(string $message, ?string $domain = null): string
     {
         /* If we don't have a domain, assume we're just using the default */
         if ($domain === null) {

--- a/src/Node/TransNode.php
+++ b/src/Node/TransNode.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of Twig.
+ * This file is part of Twig I18n extension.
  *
  * (c) 2010-2019 Fabien Potencier
  * (c) 2019-2021 phpMyAdmin contributors
@@ -34,6 +34,9 @@ use function trim;
  */
 class TransNode extends Node
 {
+    /** @var string */
+    protected static $notesLabel = '// notes: ';
+
     public function __construct(Node $body, ?Node $plural, ?AbstractExpression $count, ?Node $notes, ?Node $domain = null, int $lineno = 0, ?string $tag = null)
     {
         $nodes = ['body' => $body];
@@ -72,10 +75,6 @@ class TransNode extends Node
 
         $hasDomain = $this->hasNode('domain');
 
-        if ($hasDomain) {
-            [$msg2, $vars2] = $this->compileString($this->getNode('domain'));
-        }
-
         $function = $this->getTransFunction($hasPlural, $hasDomain);
 
         if ($this->hasNode('notes')) {
@@ -83,7 +82,7 @@ class TransNode extends Node
 
             // line breaks are not allowed cause we want a single line comment
             $message = str_replace(["\n", "\r"], ' ', $message);
-            $compiler->write('// notes: ' . $message . "\n");
+            $compiler->write(static::$notesLabel . $message . "\n");
         }
 
         if ($vars) {
@@ -91,8 +90,9 @@ class TransNode extends Node
                 ->write('echo strtr(' . $function . '(');
 
             if ($hasDomain) {
+                [$domain] = $this->compileString($this->getNode('domain'));
                 $compiler
-                    ->subcompile($msg2)
+                    ->subcompile($domain)
                     ->raw(', ');
             }
 
@@ -132,8 +132,9 @@ class TransNode extends Node
                 ->write('echo ' . $function . '(');
 
             if ($hasDomain) {
+                [$domain] = $this->compileString($this->getNode('domain'));
                 $compiler
-                    ->subcompile($msg2)
+                    ->subcompile($domain)
                     ->raw(', ');
             }
 

--- a/src/TokenParser/TransTokenParser.php
+++ b/src/TokenParser/TransTokenParser.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of Twig.
+ * This file is part of Twig I18n extension.
  *
  * (c) 2010-2019 Fabien Potencier
  * (c) 2019-2021 phpMyAdmin contributors
@@ -27,6 +27,21 @@ class TransTokenParser extends AbstractTokenParser
      * {@inheritdoc}
      */
     public function parse(Token $token)
+    {
+        [
+            $body,
+            $plural,
+            $count,
+            $notes,
+            $domain,
+            $lineno,
+            $tag,
+        ] = $this->preParse($token);
+
+        return new TransNode($body, $plural, $count, $notes, $domain, $lineno, $tag);
+    }
+
+    protected function preParse(Token $token): array
     {
         $lineno = $token->getLine();
         $stream = $this->parser->getStream();
@@ -67,7 +82,7 @@ class TransTokenParser extends AbstractTokenParser
 
         $this->checkTransString($body, $lineno);
 
-        return new TransNode($body, $plural, $count, $notes, $domain, $lineno, $this->getTag());
+        return [$body, $plural, $count, $notes, $domain, $lineno, $this->getTag()];
     }
 
     /**

--- a/src/TokenParser/TransTokenParser.php
+++ b/src/TokenParser/TransTokenParser.php
@@ -20,7 +20,6 @@ use Twig\Node\PrintNode;
 use Twig\Node\TextNode;
 use Twig\Token;
 use Twig\TokenParser\AbstractTokenParser;
-use function sprintf;
 
 class TransTokenParser extends AbstractTokenParser
 {
@@ -110,7 +109,7 @@ class TransTokenParser extends AbstractTokenParser
                 continue;
             }
 
-            throw new SyntaxError(sprintf('The text to be translated with "trans" can only contain references to simple variables'), $lineno);
+            throw new SyntaxError('The text to be translated with "trans" can only contain references to simple variables.', $lineno);
         }
     }
 }

--- a/src/TokenParser/TransTokenParser.php
+++ b/src/TokenParser/TransTokenParser.php
@@ -31,9 +31,16 @@ class TransTokenParser extends AbstractTokenParser
     {
         $lineno = $token->getLine();
         $stream = $this->parser->getStream();
+        $domain = null;
         $count = null;
         $plural = null;
         $notes = null;
+
+        /* If we aren't closing the block, do we have a domain? */
+        if ($stream->test(Token::NAME_TYPE)) {
+            $stream->expect(Token::NAME_TYPE, 'from');
+            $domain = $this->parser->getExpressionParser()->parseExpression();
+        }
 
         if (! $stream->test(Token::BLOCK_END_TYPE)) {
             $body = $this->parser->getExpressionParser()->parseExpression();
@@ -61,7 +68,7 @@ class TransTokenParser extends AbstractTokenParser
 
         $this->checkTransString($body, $lineno);
 
-        return new TransNode($body, $plural, $count, $notes, $lineno, $this->getTag());
+        return new TransNode($body, $plural, $count, $notes, $domain, $lineno, $this->getTag());
     }
 
     /**

--- a/test/Fixtures/PluralExample.test
+++ b/test/Fixtures/PluralExample.test
@@ -1,0 +1,17 @@
+--TEST--
+Test a plural example
+--TEMPLATE--
+{# Plural tag without domain #}
+{% set name = 'Jim' %}
+{% set apple_count = 2 %}
+{% trans %}
+    Hey {{ name }}, I have one apple.
+{% plural apple_count %}
+    Hey {{ name }}, I have {{ count }} apples.
+{% endtrans %}
+--DATA--
+return []
+--CONFIG--
+return []
+--EXPECT--
+Hey Jim, I have 2 apples.

--- a/test/Fixtures/PluralExampleDomain.test
+++ b/test/Fixtures/PluralExampleDomain.test
@@ -1,0 +1,17 @@
+--TEST--
+Test a plural example
+--TEMPLATE--
+{# Plural tag with domain #}
+{% set name = 'Jim' %}
+{% set apple_count = 2 %}
+{% trans from 'core' %}
+    Hey {{ name }}, I have one apple.
+{% plural apple_count %}
+    Hey {{ name }}, I have {{ count }} apples.
+{% endtrans %}
+--DATA--
+return []
+--CONFIG--
+return []
+--EXPECT--
+Hey Jim, I have 2 apples.

--- a/test/Fixtures/PluralOneExample.test
+++ b/test/Fixtures/PluralOneExample.test
@@ -1,0 +1,17 @@
+--TEST--
+Test a plural example
+--TEMPLATE--
+{# Plural tag without domain #}
+{% set name = 'Jim' %}
+{% set apple_count = 1 %}
+{% trans %}
+    Hey {{ name }}, I have one apple.
+{% plural apple_count %}
+    Hey {{ name }}, I have {{ count }} apples.
+{% endtrans %}
+--DATA--
+return []
+--CONFIG--
+return []
+--EXPECT--
+Hey Jim, I have one apple.

--- a/test/Fixtures/PluralOneExampleDomain.test
+++ b/test/Fixtures/PluralOneExampleDomain.test
@@ -1,0 +1,17 @@
+--TEST--
+Test a plural example
+--TEMPLATE--
+{# Plural tag with domain #}
+{% set name = 'Jim' %}
+{% set apple_count = 1 %}
+{% trans from 'core' %}
+    Hey {{ name }}, I have one apple.
+{% plural apple_count %}
+    Hey {{ name }}, I have {{ count }} apples.
+{% endtrans %}
+--DATA--
+return []
+--CONFIG--
+return []
+--EXPECT--
+Hey Jim, I have one apple.

--- a/test/Fixtures/PluralWithNotes.test
+++ b/test/Fixtures/PluralWithNotes.test
@@ -1,0 +1,18 @@
+--TEST--
+Test a plural example with notes
+--TEMPLATE--
+{# Plural tag with domain #}
+{% set name = 'Jim' %}
+{% set apple_count = 1 %}
+{% trans from 'core' %}
+    Hey {{ name }}, I have one apple.
+{% plural apple_count %}
+    Hey {{ name }}, I have {{ count }} apples.
+{% notes %}Notes for the plural block
+{% endtrans %}
+--DATA--
+return []
+--CONFIG--
+return []
+--EXPECT--
+Hey Jim, I have one apple.

--- a/test/Fixtures/PluralWithSprintf.test
+++ b/test/Fixtures/PluralWithSprintf.test
@@ -1,0 +1,14 @@
+--TEST--
+Test a plural example without variables in the content
+--CONFIG--
+return []
+--TEMPLATE--
+{% trans %}%s table{% plural num_tables %}%s tables{% endtrans %}
+--DATA--
+return [ 'num_tables' => 1]
+--EXPECT--
+%s table
+--DATA--
+return [ 'num_tables' => 2]
+--EXPECT--
+%s tables

--- a/test/Fixtures/SimpleDomain.test
+++ b/test/Fixtures/SimpleDomain.test
@@ -1,0 +1,11 @@
+--TEST--
+Test a simple domain example
+--TEMPLATE--
+{# With specific domain #}
+{% trans from "core" %}Castle Quote{% endtrans %}
+--DATA--
+return []
+--CONFIG--
+return []
+--EXPECT--
+Castle Quote

--- a/test/Fixtures/SimpleExample.test
+++ b/test/Fixtures/SimpleExample.test
@@ -1,0 +1,10 @@
+--TEST--
+Test a simple trans tag
+--TEMPLATE--
+{% trans %}Castle Quote{% endtrans %}
+--DATA--
+return []
+--CONFIG--
+return []
+--EXPECT--
+Castle Quote

--- a/test/Fixtures/TransFilter.test
+++ b/test/Fixtures/TransFilter.test
@@ -1,0 +1,13 @@
+--TEST--
+Test a simple trans filter
+--TEMPLATE--
+{{ 'Castle Quote'|trans }}
+{# Filter before (default domain) #}
+{{ 'Castle Quote'|trans }}
+--DATA--
+return []
+--CONFIG--
+return []
+--EXPECT--
+Castle Quote
+Castle Quote

--- a/test/Fixtures/TransFilterDomain.test
+++ b/test/Fixtures/TransFilterDomain.test
@@ -1,0 +1,11 @@
+--TEST--
+Test a simple trans filter
+--TEMPLATE--
+{# Filter with domain #}
+{{ 'Castle Quote'|trans('core') }}
+--DATA--
+return []
+--CONFIG--
+return []
+--EXPECT--
+Castle Quote

--- a/test/Fixtures/TransFunctionOutput.test
+++ b/test/Fixtures/TransFunctionOutput.test
@@ -1,0 +1,10 @@
+--TEST--
+Test with a function output
+--TEMPLATE--
+{{ max({2: "e", 1: "a", 3: "b", 5: "d", 4: "c"})|trans }}
+--DATA--
+return []
+--CONFIG--
+return []
+--EXPECT--
+e

--- a/test/Fixtures/TransTagWithNotes.test
+++ b/test/Fixtures/TransTagWithNotes.test
@@ -1,0 +1,10 @@
+--TEST--
+Test with notes
+--TEMPLATE--
+{% trans %}calendar-month-year{% notes %}Month-year order for calendar, use either "calendar-month-year" or "calendar-year-month".{% endtrans %}
+--DATA--
+return []
+--CONFIG--
+return []
+--EXPECT--
+calendar-month-year

--- a/test/Fixtures/TransTooComplex.test
+++ b/test/Fixtures/TransTooComplex.test
@@ -1,0 +1,10 @@
+--TEST--
+Test with a too complex string
+--TEMPLATE--
+{% trans %}{{ items.current }}{% endtrans %}
+--DATA--
+return ['b' => 18]
+--CONFIG--
+return []
+--EXCEPTION--
+Twig\Error\SyntaxError: The text to be translated with "trans" can only contain references to simple variables in "index.twig" at line 2.

--- a/test/Fixtures/TransVariableAndData.test
+++ b/test/Fixtures/TransVariableAndData.test
@@ -1,0 +1,10 @@
+--TEST--
+Test with a function and data
+--TEMPLATE--
+{{ max({2: "e", 1: "a", 3: b, 'b': "d", 4: "c"})|trans }}
+--DATA--
+return ['b' => 18]
+--CONFIG--
+return []
+--EXPECT--
+18

--- a/test/Fixtures/TransVariableAndData.test
+++ b/test/Fixtures/TransVariableAndData.test
@@ -1,7 +1,7 @@
 --TEST--
 Test with a function and data
 --TEMPLATE--
-{{ max({2: "e", 1: "a", 3: b, 'b': "d", 4: "c"})|trans }}
+{{ max([1,2,3,b])|trans }}
 --DATA--
 return ['b' => 18]
 --CONFIG--

--- a/test/Fixtures/VariableDomain.test
+++ b/test/Fixtures/VariableDomain.test
@@ -1,0 +1,12 @@
+--TEST--
+Test a simple domain example
+--TEMPLATE--
+{# With domain variable #}
+{% set var = 'core' %}
+{% trans from var %}Castle Quote{% endtrans %}
+--DATA--
+return []
+--CONFIG--
+return []
+--EXPECT--
+Castle Quote

--- a/test/I18nExtensionTest.php
+++ b/test/I18nExtensionTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * (c) 2021 phpMyAdmin contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpMyAdmin\Tests\Twig\Extensions\Node;
+
+use PhpMyAdmin\Twig\Extensions\I18nExtension;
+use Twig\Test\IntegrationTestCase;
+use Twig\Extension\AbstractExtension;
+
+class I18nExtensionTest extends IntegrationTestCase
+{
+    /**
+     * @return AbstractExtension[]
+     */
+    public function getExtensions()
+    {
+        return [
+            new I18nExtension(),
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    public function getFixturesDir()
+    {
+        return __DIR__ . '/Fixtures/';
+    }
+}

--- a/test/Node/TransTest.php
+++ b/test/Node/TransTest.php
@@ -44,12 +44,43 @@ class TransTest extends NodeTestCase
         $this->assertEquals($plural, $node->getNode('plural'));
     }
 
+    public function testConstructorWithDomain(): void
+    {
+        $count = new ConstantExpression(12, 0);
+        $body = new Node([
+            new TextNode('Hello', 0),
+        ], [], 0);
+        $domain = new Node([
+            new TextNode('coredomain', 0),
+        ], [], 0);
+        $plural = new Node([
+            new TextNode('Hey ', 0),
+            new PrintNode(new NameExpression('name', 0), 0),
+            new TextNode(', I have ', 0),
+            new PrintNode(new NameExpression('count', 0), 0),
+            new TextNode(' apples', 0),
+        ], [], 0);
+        $node = new TransNode($body, $plural, $count, null, $domain, 0);
+
+        $this->assertEquals($body, $node->getNode('body'));
+        $this->assertEquals($count, $node->getNode('count'));
+        $this->assertEquals($plural, $node->getNode('plural'));
+        $this->assertEquals($domain, $node->getNode('domain'));
+    }
+
     /**
      * @return array[]
      */
     public function getTests(): array
     {
         $tests = [];
+
+        $body = new NameExpression('foo', 0);
+        $domain = new Node([
+            new TextNode('coredomain', 0),
+        ], [], 0);
+        $node = new TransNode($body, null, null, null, $domain, 0);
+        $tests[] = [$node, sprintf('echo dgettext("coredomain", %s);', $this->getVariableGetter('foo'))];
 
         $body = new NameExpression('foo', 0);
         $node = new TransNode($body, null, null, null, null, 0);

--- a/test/Node/TransTest.php
+++ b/test/Node/TransTest.php
@@ -37,7 +37,7 @@ class TransTest extends NodeTestCase
             new PrintNode(new NameExpression('count', 0), 0),
             new TextNode(' apples', 0),
         ], [], 0);
-        $node = new TransNode($body, $plural, $count, null, 0);
+        $node = new TransNode($body, $plural, $count, null, null, 0);
 
         $this->assertEquals($body, $node->getNode('body'));
         $this->assertEquals($count, $node->getNode('count'));
@@ -52,17 +52,17 @@ class TransTest extends NodeTestCase
         $tests = [];
 
         $body = new NameExpression('foo', 0);
-        $node = new TransNode($body, null, null, null, 0);
+        $node = new TransNode($body, null, null, null, null, 0);
         $tests[] = [$node, sprintf('echo gettext(%s);', $this->getVariableGetter('foo'))];
 
         $body = new ConstantExpression('Hello', 0);
-        $node = new TransNode($body, null, null, null, 0);
+        $node = new TransNode($body, null, null, null, null, 0);
         $tests[] = [$node, 'echo gettext("Hello");'];
 
         $body = new Node([
             new TextNode('Hello', 0),
         ], [], 0);
-        $node = new TransNode($body, null, null, null, 0);
+        $node = new TransNode($body, null, null, null, null, 0);
         $tests[] = [$node, 'echo gettext("Hello");'];
 
         $body = new Node([
@@ -70,7 +70,7 @@ class TransTest extends NodeTestCase
             new PrintNode(new NameExpression('foo', 0), 0),
             new TextNode(' pommes', 0),
         ], [], 0);
-        $node = new TransNode($body, null, null, null, 0);
+        $node = new TransNode($body, null, null, null, null, 0);
         $tests[] = [$node, sprintf('echo strtr(gettext("J\'ai %%foo%% pommes"), array("%%foo%%" => %s, ));', $this->getVariableGetter('foo'))];
 
         $count = new ConstantExpression(12, 0);
@@ -86,7 +86,7 @@ class TransTest extends NodeTestCase
             new PrintNode(new NameExpression('count', 0), 0),
             new TextNode(' apples', 0),
         ], [], 0);
-        $node = new TransNode($body, $plural, $count, null, 0);
+        $node = new TransNode($body, $plural, $count, null, null, 0);
         $tests[] = [$node, sprintf('echo strtr(ngettext("Hey %%name%%, I have one apple", "Hey %%name%%, I have %%count%% apples", abs(12)), array("%%name%%" => %s, "%%name%%" => %s, "%%count%%" => abs(12), ));', $this->getVariableGetter('name'), $this->getVariableGetter('name'))];
 
         // with escaper extension set to on
@@ -96,18 +96,18 @@ class TransTest extends NodeTestCase
             new TextNode(' pommes', 0),
         ], [], 0);
 
-        $node = new TransNode($body, null, null, null, 0);
+        $node = new TransNode($body, null, null, null, null, 0);
         $tests[] = [$node, sprintf('echo strtr(gettext("J\'ai %%foo%% pommes"), array("%%foo%%" => %s, ));', $this->getVariableGetter('foo'))];
 
         // with notes
         $body = new ConstantExpression('Hello', 0);
         $notes = new TextNode('Notes for translators', 0);
-        $node = new TransNode($body, null, null, $notes, 0);
+        $node = new TransNode($body, null, null, $notes, null, 0);
         $tests[] = [$node, "// notes: Notes for translators\necho gettext(\"Hello\");"];
 
         $body = new ConstantExpression('Hello', 0);
         $notes = new TextNode("Notes for translators\nand line breaks", 0);
-        $node = new TransNode($body, null, null, $notes, 0);
+        $node = new TransNode($body, null, null, $notes, null, 0);
         $tests[] = [$node, "// notes: Notes for translators and line breaks\necho gettext(\"Hello\");"];
 
         $count = new ConstantExpression(5, 0);
@@ -118,7 +118,7 @@ class TransTest extends NodeTestCase
             new TextNode(' pending tasks', 0),
         ], [], 0);
         $notes = new TextNode('Notes for translators', 0);
-        $node = new TransNode($body, $plural, $count, $notes, 0);
+        $node = new TransNode($body, $plural, $count, $notes, null, 0);
         $tests[] = [$node, "// notes: Notes for translators\n" . 'echo strtr(ngettext("There is 1 pending task", "There are %count% pending tasks", abs(5)), array("%count%" => abs(5), ));'];
 
         return $tests;


### PR DESCRIPTION
So it turns out that this was actually much easier to implement than I originally thought. I've tested the code and it's working with/without specific domain translation. You can now translate via a domain using the trans filter as well as blocks, but the filter still doesn't accept plurals (for obvious reasons).

In addition to this, you can also now translate with variables as well as hard-coded domain strings.

```twig
{# Original (default domain) #}
{% trans %}Castle Quote{% endtrans %}

{# With specific domain #}
{% trans from "core" %}Castle Quote{% endtrans %}

{# With domain variable #}
{% set var = 'core' %}
{% trans from var %}Castle Quote{% endtrans %}

{# Filter before (default domain) #}
{{ 'Castle Quote'|trans }}

{# Filter with domain #}
{{ 'Castle Quote'|trans('core') }}

{# Plural tag without domain #}
{% set name = 'Jim' %}
{% set apple_count = 2 %}
{% trans %}
    Hey {{ name }}, I have one apple.
{% plural apple_count %}
    Hey {{ name }}, I have {{ count }} apples.
{% endtrans %}

{# Plural tag with domain #}
{% trans from 'core' %}
    Hey {{ name }}, I have one apple.
{% plural apple_count %}
    Hey {{ name }}, I have {{ count }} apples.
{% endtrans %}

{# Plural tag with variable domain #}
{% trans from var %}
    Hey {{ name }}, I have one apple.
{% plural apple_count %}
    Hey {{ name }}, I have {{ count }} apples.
{% endtrans %}
```

Fixes: #4