### PR TITLE
Drop support for Twig 1 and Twig 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require": {
         "php": "^7.2 || ^8.0",
-        "twig/twig": "^1.42.3 || ^2.0 || ^3.0"
+        "twig/twig": "^3.11.3"
     },
     "require-dev": {
         "phpmyadmin/coding-standard": "^3.0.0",


### PR DESCRIPTION
If PHP 7.2+ is required, there's no reason to support old Twig versions anymore.

I'm thinking about releasing this with the version 4.2.0.