### PR TITLE
Add support for PHPUnit 10, 11, 12 and 13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 composer.lock
 phpcs.xml
 .phpcs-cache
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,10 @@
         "twig/twig": "^3.11.3"
     },
     "require-dev": {
-        "phpmyadmin/coding-standard": "^3.0.0",
-        "phpmyadmin/motranslator": "^5.2",
-        "phpstan/phpstan": "^1.9.4",
-        "phpunit/phpunit": "^8.5 || ^9.6"
+        "phpmyadmin/coding-standard": "^3.0",
+        "phpmyadmin/motranslator": "^5.4",
+        "phpstan/phpstan": "^1.12",
+        "phpunit/phpunit": "^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12.5 || ^13.2"
     },
     "scripts": {
         "phpstan": "./vendor/bin/phpstan analyse",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,4 +4,3 @@ parameters:
         - src
         - test
     reportUnmatchedIgnoredErrors: true
-    checkMissingIterableValueType: false

--- a/src/Node/TransNode.php
+++ b/src/Node/TransNode.php
@@ -34,6 +34,7 @@ use function count;
 use function sprintf;
 use function str_replace;
 use function trim;
+use function version_compare;
 
 /**
  * Represents a trans node.
@@ -103,7 +104,7 @@ class TransNode extends Node
         }
 
         /** @phpstan-ignore-next-line */
-        if (Environment::MAJOR_VERSION >= 3 && Environment::MINOR_VERSION >= 12) {
+        if (version_compare(Environment::VERSION, '3.12.0', '>=')) {
             parent::__construct($nodes, [], $lineno);
 
             return;
@@ -232,6 +233,8 @@ class TransNode extends Node
 
     /**
      * Keep this method protected instead of private some implementations may use it
+     *
+     * @return array{Node, list<NameExpression>}
      */
     protected function compileString(Node $body): array
     {
@@ -261,7 +264,9 @@ class TransNode extends Node
                     $attributeName = $n->getAttribute('name');
                     $msg .= sprintf('%%%s%%', $attributeName);
                     if (class_exists(ContextVariable::class)) {
-                        $vars[] = new ContextVariable($attributeName, $n->getTemplateLine());
+                        /** @var NameExpression $contextVariable */
+                        $contextVariable = new ContextVariable($attributeName, $n->getTemplateLine());
+                        $vars[] = $contextVariable;
                     } else {
                         $vars[] = new NameExpression($attributeName, $n->getTemplateLine());
                     }

--- a/src/TokenParser/TransTokenParser.php
+++ b/src/TokenParser/TransTokenParser.php
@@ -17,6 +17,7 @@ namespace PhpMyAdmin\Twig\Extensions\TokenParser;
 use PhpMyAdmin\Twig\Extensions\Node\I18nNode;
 use PhpMyAdmin\Twig\Extensions\Node\TransNode;
 use Twig\Error\SyntaxError;
+use Twig\Node\Expression\AbstractExpression;
 use Twig\Node\Expression\NameExpression;
 use Twig\Node\Node;
 use Twig\Node\PrintNode;
@@ -47,6 +48,18 @@ class TransTokenParser extends AbstractTokenParser
         return new TransNode($body, $plural, $count, $context, $notes, $domain, $lineno, $tag);
     }
 
+    /**
+     * @return array{
+     *     Node,
+     *     Node|null,
+     *     AbstractExpression|null,
+     *     Node|null,
+     *     Node|null,
+     *     Node|null,
+     *     int,
+     *     string|null
+     * }
+     */
     protected function preParse(Token $token): array
     {
         $lineno = $token->getLine();

--- a/test/I18nExtensionMoTranslatorDebugTest.php
+++ b/test/I18nExtensionMoTranslatorDebugTest.php
@@ -9,15 +9,14 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpMyAdmin\Tests\Twig\Extensions\Node;
+namespace PhpMyAdmin\Tests\Twig\Extensions;
 
 use PhpMyAdmin\MoTranslator\Loader;
 use PhpMyAdmin\Tests\Twig\Extensions\MoTranslator\I18nExtensionDebug;
 use PhpMyAdmin\Twig\Extensions\I18nExtension;
 use Twig\Extension\AbstractExtension;
-use Twig\Test\IntegrationTestCase;
 
-class I18nExtensionMoTranslatorDebugTest extends IntegrationTestCase
+final class I18nExtensionMoTranslatorDebugTest extends IntegrationTestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -27,23 +26,20 @@ class I18nExtensionMoTranslatorDebugTest extends IntegrationTestCase
     /**
      * @return AbstractExtension[]
      */
-    public function getExtensions()
+    public function getExtensions(): array
     {
         return [
             new I18nExtensionDebug(),
         ];
     }
 
-    /**
-     * @return string
-     */
-    public function getFixturesDir()
+    protected static function getFixturesDirectory(): string
     {
         return __DIR__ . '/Fixtures/';
     }
 
     public function testGetName(): void
     {
-        $this->assertNotEmpty((new I18nExtension())->getName());
+        self::assertNotEmpty((new I18nExtension())->getName());
     }
 }

--- a/test/I18nExtensionMoTranslatorSandboxTest.php
+++ b/test/I18nExtensionMoTranslatorSandboxTest.php
@@ -9,26 +9,21 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpMyAdmin\Tests\Twig\Extensions\Node;
+namespace PhpMyAdmin\Tests\Twig\Extensions;
 
 use PhpMyAdmin\MoTranslator\Loader;
 use PhpMyAdmin\Twig\Extensions\I18nExtension;
-use Twig\Extension\AbstractExtension;
 use Twig\Extension\SandboxExtension;
 use Twig\Sandbox\SecurityPolicy;
-use Twig\Test\IntegrationTestCase;
 
-class I18nExtensionMoTranslatorSandboxTest extends IntegrationTestCase
+final class I18nExtensionMoTranslatorSandboxTest extends IntegrationTestCase
 {
     public static function setUpBeforeClass(): void
     {
         Loader::loadFunctions();
     }
 
-    /**
-     * @return AbstractExtension[]
-     */
-    public function getExtensions()
+    public function getExtensions(): array
     {
         $tags = ['if', 'set', 'trans'];
         $filters = ['upper', 'escape'];
@@ -43,16 +38,13 @@ class I18nExtensionMoTranslatorSandboxTest extends IntegrationTestCase
         ];
     }
 
-    /**
-     * @return string
-     */
-    public function getFixturesDir()
+    protected static function getFixturesDirectory(): string
     {
         return __DIR__ . '/FixturesWithSandbox/';
     }
 
     public function testGetName(): void
     {
-        $this->assertNotEmpty((new I18nExtension())->getName());
+        self::assertNotEmpty((new I18nExtension())->getName());
     }
 }

--- a/test/I18nExtensionMoTranslatorTest.php
+++ b/test/I18nExtensionMoTranslatorTest.php
@@ -9,34 +9,26 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpMyAdmin\Tests\Twig\Extensions\Node;
+namespace PhpMyAdmin\Tests\Twig\Extensions;
 
 use PhpMyAdmin\MoTranslator\Loader;
 use PhpMyAdmin\Tests\Twig\Extensions\MoTranslator\I18nExtensionMoTranslator;
-use Twig\Extension\AbstractExtension;
-use Twig\Test\IntegrationTestCase;
 
-class I18nExtensionMoTranslatorTest extends IntegrationTestCase
+final class I18nExtensionMoTranslatorTest extends IntegrationTestCase
 {
     public static function setUpBeforeClass(): void
     {
         Loader::loadFunctions();
     }
 
-    /**
-     * @return AbstractExtension[]
-     */
-    public function getExtensions()
+    public function getExtensions(): array
     {
         return [
             new I18nExtensionMoTranslator(),
         ];
     }
 
-    /**
-     * @return string
-     */
-    public function getFixturesDir()
+    protected static function getFixturesDirectory(): string
     {
         return __DIR__ . '/Fixtures/';
     }

--- a/test/I18nExtensionSandboxTest.php
+++ b/test/I18nExtensionSandboxTest.php
@@ -9,20 +9,15 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpMyAdmin\Tests\Twig\Extensions\Node;
+namespace PhpMyAdmin\Tests\Twig\Extensions;
 
 use PhpMyAdmin\Twig\Extensions\I18nExtension;
-use Twig\Extension\AbstractExtension;
 use Twig\Extension\SandboxExtension;
 use Twig\Sandbox\SecurityPolicy;
-use Twig\Test\IntegrationTestCase;
 
-class I18nExtensionSandboxTest extends IntegrationTestCase
+final class I18nExtensionSandboxTest extends IntegrationTestCase
 {
-    /**
-     * @return AbstractExtension[]
-     */
-    public function getExtensions()
+    public function getExtensions(): array
     {
         $tags = ['if', 'set', 'trans'];
         $filters = ['upper', 'escape'];
@@ -37,16 +32,13 @@ class I18nExtensionSandboxTest extends IntegrationTestCase
         ];
     }
 
-    /**
-     * @return string
-     */
-    public function getFixturesDir()
+    protected static function getFixturesDirectory(): string
     {
         return __DIR__ . '/FixturesWithSandbox/';
     }
 
     public function testGetName(): void
     {
-        $this->assertNotEmpty((new I18nExtension())->getName());
+        self::assertNotEmpty((new I18nExtension())->getName());
     }
 }

--- a/test/I18nExtensionTest.php
+++ b/test/I18nExtensionTest.php
@@ -9,34 +9,26 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpMyAdmin\Tests\Twig\Extensions\Node;
+namespace PhpMyAdmin\Tests\Twig\Extensions;
 
 use PhpMyAdmin\Twig\Extensions\I18nExtension;
-use Twig\Extension\AbstractExtension;
-use Twig\Test\IntegrationTestCase;
 
-class I18nExtensionTest extends IntegrationTestCase
+final class I18nExtensionTest extends IntegrationTestCase
 {
-    /**
-     * @return AbstractExtension[]
-     */
-    public function getExtensions()
+    public function getExtensions(): array
     {
         return [
             new I18nExtension(),
         ];
     }
 
-    /**
-     * @return string
-     */
-    public function getFixturesDir()
+    protected static function getFixturesDirectory(): string
     {
         return __DIR__ . '/Fixtures/';
     }
 
     public function testGetName(): void
     {
-        $this->assertNotEmpty((new I18nExtension())->getName());
+        self::assertNotEmpty((new I18nExtension())->getName());
     }
 }

--- a/test/IntegrationTestCase.php
+++ b/test/IntegrationTestCase.php
@@ -1,0 +1,459 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpMyAdmin\Tests\Twig\Extensions;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Constraint\Exception;
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+use Throwable;
+use Twig\Environment;
+use Twig\Error\Error;
+use Twig\Extension\ExtensionInterface;
+use Twig\Loader\ArrayLoader;
+use Twig\RuntimeLoader\RuntimeLoaderInterface;
+use Twig\TokenParser\TokenParserInterface;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
+use Twig\TwigTest;
+
+use function array_keys;
+use function array_merge;
+use function explode;
+use function file_get_contents;
+use function get_class;
+use function implode;
+use function method_exists;
+use function preg_match;
+use function preg_match_all;
+use function printf;
+use function realpath;
+use function restore_error_handler;
+use function set_error_handler;
+use function sprintf;
+use function str_contains;
+use function str_repeat;
+use function str_replace;
+use function strlen;
+use function substr;
+use function trim;
+
+use const E_USER_DEPRECATED;
+use const PREG_SET_ORDER;
+
+// phpcs:disable SlevomatCodingStandard.Namespaces.UnusedUses.MismatchingCaseSensitivity
+
+/**
+ * Integration test helper.
+ */
+abstract class IntegrationTestCase extends TestCase
+{
+    abstract protected static function getFixturesDirectory(): string;
+
+    /**
+     * @return RuntimeLoaderInterface[]
+     */
+    protected function getRuntimeLoaders(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return ExtensionInterface[]
+     */
+    protected function getExtensions(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return TwigFilter[]
+     */
+    protected function getTwigFilters(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return TwigFunction[]
+     */
+    protected function getTwigFunctions(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return TwigTest[]
+     */
+    protected function getTwigTests(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<callable(string): (TwigFilter|false)>
+     */
+    protected function getUndefinedFilterCallbacks(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<callable(string): (TwigFunction|false)>
+     */
+    protected function getUndefinedFunctionCallbacks(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<callable(string): (TwigTest|false)>
+     */
+    protected function getUndefinedTestCallbacks(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<callable(string): (TokenParserInterface|false)>
+     */
+    protected function getUndefinedTokenParserCallbacks(): array
+    {
+        return [];
+    }
+
+    /**
+     * @param array<string, string>                                       $templates
+     * @param string|false                                                $exception
+     * @param array<int, array{string|null, string, string|null, string}> $outputs
+     *
+     * @dataProvider provideTests
+     */
+    #[DataProvider('provideTests')]
+    public function testIntegration(
+        string $file,
+        string $message,
+        string $condition,
+        array $templates,
+        $exception,
+        array $outputs,
+        string $deprecation = ''
+    ): void {
+        $this->doIntegrationTest($file, $message, $condition, $templates, $exception, $outputs, $deprecation);
+    }
+
+    /**
+     * @param array<string, string>                                       $templates
+     * @param string|false                                                $exception
+     * @param array<int, array{string|null, string, string|null, string}> $outputs
+     *
+     * @dataProvider provideLegacyTests
+     * @group legacy
+     */
+    #[DataProvider('provideLegacyTests'), Group('legacy')]
+    public function testLegacyIntegration(
+        string $file,
+        string $message,
+        string $condition,
+        array $templates,
+        $exception,
+        array $outputs,
+        string $deprecation = ''
+    ): void {
+        $this->doIntegrationTest($file, $message, $condition, $templates, $exception, $outputs, $deprecation);
+    }
+
+    /**
+     * @return iterable<array{
+     *     string,
+     *     string,
+     *     string,
+     *     array<string, string>,
+     *     string|false,
+     *     array<int, array{string|null, string, string|null, string}>,
+     *     string
+     * }>
+     */
+    final public static function provideTests(): iterable
+    {
+        return self::assembleTests(false, static::getFixturesDirectory());
+    }
+
+    /**
+     * @return iterable<array{
+     *     string,
+     *     string,
+     *     string,
+     *     array<string, string>,
+     *     string|false,
+     *     array<int, array{string|null, string, string|null, string}>,
+     *     string
+     * }>
+     */
+    final public static function provideLegacyTests(): iterable
+    {
+        return self::assembleTests(true, static::getFixturesDirectory());
+    }
+
+    /**
+     * @return iterable<array{
+     *     string,
+     *     string,
+     *     string,
+     *     array<string, string>,
+     *     string|false,
+     *     array<int, array{string|null, string, string|null, string}>,
+     *     string
+     * }>
+     */
+    private static function assembleTests(bool $legacyTests, string $fixturesDir): iterable
+    {
+        $fixturesDir = (string) realpath($fixturesDir);
+        $tests = [];
+
+        $files = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($fixturesDir),
+            RecursiveIteratorIterator::LEAVES_ONLY
+        );
+        /** @var SplFileInfo $file */
+        foreach ($files as $file) {
+            if (! preg_match('/\.test$/', (string) $file)) {
+                continue;
+            }
+
+            if ($legacyTests xor str_contains($file->getRealpath(), '.legacy.test')) {
+                continue;
+            }
+
+            $test = file_get_contents($file->getRealpath());
+            self::assertIsString($test);
+
+            // phpcs:disable Generic.Files.LineLength.TooLong
+            if (preg_match('/--TEST--\s*(.*?)\s*(?:--CONDITION--\s*(.*))?\s*(?:--DEPRECATION--\s*(.*?))?\s*((?:--TEMPLATE(?:\(.*?\))?--(?:.*?))+)\s*(?:--DATA--\s*(.*))?\s*--EXCEPTION--\s*(.*)/sx', $test, $match)) {
+                $message = $match[1];
+                $condition = $match[2];
+                $deprecation = $match[3];
+                $templates = self::parseTemplates($match[4]);
+                $exception = $match[6];
+                $outputs = [[null, $match[5], null, '']];
+            } elseif (preg_match('/--TEST--\s*(.*?)\s*(?:--CONDITION--\s*(.*))?\s*(?:--DEPRECATION--\s*(.*?))?\s*((?:--TEMPLATE(?:\(.*?\))?--(?:.*?))+)--DATA--.*?--EXPECT--.*/s', $test, $match)) {
+                $message = $match[1];
+                $condition = $match[2];
+                $deprecation = $match[3];
+                $templates = self::parseTemplates($match[4]);
+                $exception = false;
+                preg_match_all('/--DATA--(.*?)(?:--CONFIG--(.*?))?--EXPECT--(.*?)(?=\-\-DATA\-\-|$)/s', $test, $outputs, PREG_SET_ORDER);
+            } else {
+                throw new InvalidArgumentException(
+                    sprintf('Test "%s" is not valid.', str_replace($fixturesDir . '/', '', (string) $file))
+                );
+            }
+
+            // phpcs:enable
+
+            $tests[str_replace($fixturesDir . '/', '', (string) $file)] = [
+                str_replace($fixturesDir . '/', '', (string) $file),
+                $message,
+                $condition,
+                $templates,
+                $exception,
+                $outputs,
+                $deprecation,
+            ];
+        }
+
+        if ($legacyTests && ! $tests) {
+            // add a dummy test to avoid a PHPUnit message
+            return [['not', '-', '', [], '', [], '']];
+        }
+
+        return $tests;
+    }
+
+    /**
+     * @param array<string, string>                                       $templateSources
+     * @param string|false                                                $exception
+     * @param array<int, array{string|null, string, string|null, string}> $outputs
+     */
+    protected function doIntegrationTest(
+        string $file,
+        string $message,
+        string $condition,
+        array $templateSources,
+        $exception,
+        array $outputs,
+        string $deprecation = ''
+    ): void {
+        if (! $outputs) {
+            // dummy test added by assembleTests() when there is no (legacy) test to run
+            $this->expectNotToPerformAssertions();
+
+            return;
+        }
+
+        if ($condition) {
+            self::assertSame('asdfasdf', $condition);
+            $ret = '';
+            eval('$ret = ' . $condition . ';');
+            /** @phpstan-ignore-next-line */
+            if (! $ret) {
+                self::markTestSkipped($condition);
+            }
+        }
+
+        foreach ($outputs as $i => $match) {
+            $config = array_merge([
+                'cache' => false,
+                'strict_variables' => true,
+            ], $match[2] ? eval($match[2] . ';') : []);
+            // make sure that template are always compiled even if they are the same
+            // (useful when testing with more than one data/expect sections)
+            foreach ($templateSources as $name => $template) {
+                $templateSources[$name] = $template . str_repeat(' ', $i);
+            }
+
+            $loader = new ArrayLoader($templateSources);
+            $twig = new Environment($loader, $config);
+            $twig->addGlobal('global', 'global');
+            foreach ($this->getRuntimeLoaders() as $runtimeLoader) {
+                $twig->addRuntimeLoader($runtimeLoader);
+            }
+
+            foreach ($this->getExtensions() as $extension) {
+                $twig->addExtension($extension);
+            }
+
+            foreach ($this->getTwigFilters() as $filter) {
+                $twig->addFilter($filter);
+            }
+
+            foreach ($this->getTwigTests() as $test) {
+                $twig->addTest($test);
+            }
+
+            foreach ($this->getTwigFunctions() as $function) {
+                $twig->addFunction($function);
+            }
+
+            foreach ($this->getUndefinedFilterCallbacks() as $callback) {
+                $twig->registerUndefinedFilterCallback($callback);
+            }
+
+            foreach ($this->getUndefinedFunctionCallbacks() as $callback) {
+                $twig->registerUndefinedFunctionCallback($callback);
+            }
+
+            if (method_exists($twig, 'registerUndefinedTestCallback')) {
+                foreach ($this->getUndefinedTestCallbacks() as $callback) {
+                    $twig->registerUndefinedTestCallback($callback);
+                }
+            }
+
+            foreach ($this->getUndefinedTokenParserCallbacks() as $callback) {
+                $twig->registerUndefinedTokenParserCallback($callback);
+            }
+
+            $deprecations = [];
+            $templates = [];
+            try {
+                $prevHandler = set_error_handler(
+                    static function ($type, $msg, $file, $line, $context = []) use (&$deprecations, &$prevHandler) {
+                        if ($type === E_USER_DEPRECATED) {
+                            $deprecations[] = $msg;
+
+                            return true;
+                        }
+
+                        return $prevHandler ? $prevHandler($type, $msg, $file, $line, $context) : false;
+                    }
+                );
+
+                foreach (array_keys($templateSources) as $templateName) {
+                    $templates[$templateName] = $twig->load($templateName);
+                }
+            } catch (Throwable $e) {
+                if ($exception !== false) {
+                    $message = $e->getMessage();
+                    self::assertSame(trim($exception), trim(sprintf('%s: %s', get_class($e), $message)));
+                    $last = substr($message, strlen($message) - 1);
+                    self::assertTrue(
+                        $last === '.' || $last === '?',
+                        'Exception message must end with a dot or a question mark.'
+                    );
+
+                    return;
+                }
+
+                throw new Error(sprintf('%s: %s', get_class($e), $e->getMessage()), -1, null, $e);
+            } finally {
+                restore_error_handler();
+            }
+
+            $template = $templates['index.twig'];
+
+            try {
+                $output = trim($template->render(eval($match[1] . ';')), "\n ");
+            } catch (Throwable $e) {
+                if ($exception !== false) {
+                    self::assertStringMatchesFormat(
+                        trim($exception),
+                        trim(sprintf('%s: %s', get_class($e), $e->getMessage()))
+                    );
+
+                    return;
+                }
+
+                $e = new Error(sprintf('%s: %s', get_class($e), $e->getMessage()), -1, null, $e);
+
+                $output = trim(sprintf('%s: %s', get_class($e), $e->getMessage()));
+            }
+
+            if ($exception !== false) {
+                [$class] = explode(':', $exception);
+                self::assertThat(null, new Exception($class));
+            }
+
+            $expected = trim($match[3], "\n ");
+
+            if ($expected !== $output) {
+                printf("Compiled templates that failed on case %d:\n", $i + 1);
+
+                foreach (array_keys($templateSources) as $name) {
+                    echo 'Template: ' . $name . "\n";
+                    echo $twig->compile($twig->parse($twig->tokenize($twig->getLoader()->getSourceContext($name))));
+                }
+            }
+
+            self::assertEquals($expected, $output, $message . ' (in ' . $file . ')');
+
+            self::assertSame($deprecation, implode("\n", $deprecations));
+        }
+    }
+
+    /** @return array<string, string> */
+    protected static function parseTemplates(string $test): array
+    {
+        $templates = [];
+        preg_match_all('/--TEMPLATE(?:\((.*?)\))?--(.*?)(?=\-\-TEMPLATE|$)/s', $test, $matches, PREG_SET_ORDER);
+        foreach ($matches as $match) {
+            $templates[$match[1] ?: 'index.twig'] = $match[2];
+        }
+
+        return $templates;
+    }
+}

--- a/test/Node/MoTranslatorTransTest.php
+++ b/test/Node/MoTranslatorTransTest.php
@@ -14,36 +14,16 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Twig\Extensions\Node;
 
+use PhpMyAdmin\Tests\Twig\Extensions\NodeTestCase;
 use PhpMyAdmin\Twig\Extensions\Node\TransNode;
-use Twig\Attribute\YieldReady;
-use Twig\Environment;
 use Twig\Node\Expression\ConstantExpression;
-use Twig\Node\Expression\NameExpression;
 use Twig\Node\PrintNode;
 use Twig\Node\TextNode;
-use Twig\Test\NodeTestCase;
 
-use function class_exists;
 use function sprintf;
-use function version_compare;
 
-class MoTranslatorTransTest extends NodeTestCase
+final class MoTranslatorTransTest extends NodeTestCase
 {
-    private static function echoOrYield(): string
-    {
-        return class_exists(YieldReady::class) ? 'yield' : 'echo';
-    }
-
-    /**
-     * Twig 3.26 encodes single quotes as \x27 (not ') in compiled string literals
-     * as a defense-in-depth measure, so the expected output differs by Twig version.
-     */
-    private static function apostrophe(): string
-    {
-        /** @phpstan-ignore-next-line */
-        return version_compare(Environment::VERSION, '3.26.0', '>=') ? '\\x27' : '\'';
-    }
-
     public static function setUpBeforeClass(): void
     {
         TransNode::$notesLabel = '// l10n: ';
@@ -73,39 +53,36 @@ class MoTranslatorTransTest extends NodeTestCase
         ]);
         $plural = new Nodes([
             new TextNode('Hey ', 0),
-            new PrintNode(new NameExpression('name', 0), 0),
+            new PrintNode(self::createContextVariable('name', 0), 0),
             new TextNode(', I have ', 0),
-            new PrintNode(new NameExpression('count', 0), 0),
+            new PrintNode(self::createContextVariable('count', 0), 0),
             new TextNode(' apples', 0),
         ]);
         $node = new TransNode($body, $plural, $count, $context, $notes, $domain, 0);
 
-        $this->assertEquals($body, $node->getNode('body'));
-        $this->assertEquals($count, $node->getNode('count'));
-        $this->assertEquals($plural, $node->getNode('plural'));
-        $this->assertEquals($notes, $node->getNode('notes'));
-        $this->assertEquals($domain, $node->getNode('domain'));
-        $this->assertEquals($context, $node->getNode('context'));
+        self::assertEquals($body, $node->getNode('body'));
+        self::assertEquals($count, $node->getNode('count'));
+        self::assertEquals($plural, $node->getNode('plural'));
+        self::assertEquals($notes, $node->getNode('notes'));
+        self::assertEquals($domain, $node->getNode('domain'));
+        self::assertEquals($context, $node->getNode('context'));
     }
 
-    /**
-     * @return array[]
-     */
-    public function getTests(): array
+    public static function provideTests(): iterable
     {
         $tests = [];
 
-        $body = new NameExpression('foo', 0);
+        $body = self::createContextVariable('foo', 0);
         $domain = new Nodes([
             new TextNode('coredomain', 0),
         ]);
         $node = new TransNode($body, null, null, null, null, $domain, 0);
         $tests[] = [
             $node,
-            sprintf(self::echoOrYield() . ' _dgettext("coredomain", %s);', $this->getVariableGetter('foo')),
+            sprintf(self::echoOrYield() . ' _dgettext("coredomain", %s);', self::createVariableGetter('foo')),
         ];
 
-        $body = new NameExpression('foo', 0);
+        $body = self::createContextVariable('foo', 0);
         $domain = new Nodes([
             new TextNode('coredomain', 0),
         ]);
@@ -117,13 +94,13 @@ class MoTranslatorTransTest extends NodeTestCase
             $node,
             sprintf(
                 self::echoOrYield() . ' _dpgettext("coredomain", "The context", %s);',
-                $this->getVariableGetter('foo')
+                self::createVariableGetter('foo')
             ),
         ];
 
         $body = new Nodes([
             new TextNode('J\'ai ', 0),
-            new PrintNode(new NameExpression('foo', 0), 0),
+            new PrintNode(self::createContextVariable('foo', 0), 0),
             new TextNode(' pommes', 0),
         ]);
         $node = new TransNode($body, null, null, null, null, null, 0);
@@ -132,21 +109,21 @@ class MoTranslatorTransTest extends NodeTestCase
             sprintf(
                 self::echoOrYield() . ' strtr(_gettext("J' . self::apostrophe()
                     . 'ai %%foo%% pommes"), array("%%foo%%" => %s, ));',
-                $this->getVariableGetter('foo')
+                self::createVariableGetter('foo')
             ),
         ];
 
         $count = new ConstantExpression(12, 0);
         $body = new Nodes([
             new TextNode('Hey ', 0),
-            new PrintNode(new NameExpression('name', 0), 0),
+            new PrintNode(self::createContextVariable('name', 0), 0),
             new TextNode(', I have one apple', 0),
         ]);
         $plural = new Nodes([
             new TextNode('Hey ', 0),
-            new PrintNode(new NameExpression('name', 0), 0),
+            new PrintNode(self::createContextVariable('name', 0), 0),
             new TextNode(', I have ', 0),
-            new PrintNode(new NameExpression('count', 0), 0),
+            new PrintNode(self::createContextVariable('count', 0), 0),
             new TextNode(' apples', 0),
         ]);
         $node = new TransNode($body, $plural, $count, null, null, null, 0);
@@ -156,14 +133,14 @@ class MoTranslatorTransTest extends NodeTestCase
                 self::echoOrYield() . ' strtr(_ngettext("Hey %%name%%, I have one apple", "Hey %%name%%,'
                 . ' I have %%count%% apples", abs(12)), array("%%name%%" => %s,'
                 . ' "%%name%%" => %s, "%%count%%" => abs(12), ));',
-                $this->getVariableGetter('name'),
-                $this->getVariableGetter('name')
+                self::createVariableGetter('name'),
+                self::createVariableGetter('name')
             ),
         ];
 
         $body = new Nodes([
             new TextNode('J\'ai ', 0),
-            new PrintNode(new NameExpression('foo', 0), 0),
+            new PrintNode(self::createContextVariable('foo', 0), 0),
             new TextNode(' pommes', 0),
         ]);
         $context = new Nodes([
@@ -176,14 +153,14 @@ class MoTranslatorTransTest extends NodeTestCase
                 self::echoOrYield()
                 . ' strtr(_pgettext("The context", "J' . self::apostrophe()
                 . 'ai %%foo%% pommes"), array("%%foo%%" => %s, ));',
-                $this->getVariableGetter('foo')
+                self::createVariableGetter('foo')
             ),
         ];
 
         $count = new ConstantExpression(12, 0);
         $body = new Nodes([
             new TextNode('Hey ', 0),
-            new PrintNode(new NameExpression('name', 0), 0),
+            new PrintNode(self::createContextVariable('name', 0), 0),
             new TextNode(', I have one apple', 0),
         ]);
         $context = new Nodes([
@@ -191,9 +168,9 @@ class MoTranslatorTransTest extends NodeTestCase
         ]);
         $plural = new Nodes([
             new TextNode('Hey ', 0),
-            new PrintNode(new NameExpression('name', 0), 0),
+            new PrintNode(self::createContextVariable('name', 0), 0),
             new TextNode(', I have ', 0),
-            new PrintNode(new NameExpression('count', 0), 0),
+            new PrintNode(self::createContextVariable('count', 0), 0),
             new TextNode(' apples', 0),
         ]);
         $node = new TransNode($body, $plural, $count, $context, null, null, 0);
@@ -204,14 +181,14 @@ class MoTranslatorTransTest extends NodeTestCase
                 . ' strtr(_npgettext("The context", "Hey %%name%%, I have one apple", "Hey %%name%%,'
                 . ' I have %%count%% apples", abs(12)), array("%%name%%" => %s,'
                 . ' "%%name%%" => %s, "%%count%%" => abs(12), ));',
-                $this->getVariableGetter('name'),
-                $this->getVariableGetter('name')
+                self::createVariableGetter('name'),
+                self::createVariableGetter('name')
             ),
         ];
 
         $body = new Nodes([
             new TextNode('J\'ai ', 0),
-            new PrintNode(new NameExpression('foo', 0), 0),
+            new PrintNode(self::createContextVariable('foo', 0), 0),
             new TextNode(' pommes', 0),
         ]);
         $context = new Nodes([
@@ -227,14 +204,14 @@ class MoTranslatorTransTest extends NodeTestCase
                 self::echoOrYield()
                 . ' strtr(_dpgettext("mydomain", "The context", "J' . self::apostrophe()
                 . 'ai %%foo%% pommes"), array("%%foo%%" => %s, ));',
-                $this->getVariableGetter('foo')
+                self::createVariableGetter('foo')
             ),
         ];
 
         $count = new ConstantExpression(12, 0);
         $body = new Nodes([
             new TextNode('Hey ', 0),
-            new PrintNode(new NameExpression('name', 0), 0),
+            new PrintNode(self::createContextVariable('name', 0), 0),
             new TextNode(', I have one apple', 0),
         ]);
         $context = new Nodes([
@@ -245,9 +222,9 @@ class MoTranslatorTransTest extends NodeTestCase
         ]);
         $plural = new Nodes([
             new TextNode('Hey ', 0),
-            new PrintNode(new NameExpression('name', 0), 0),
+            new PrintNode(self::createContextVariable('name', 0), 0),
             new TextNode(', I have ', 0),
-            new PrintNode(new NameExpression('count', 0), 0),
+            new PrintNode(self::createContextVariable('count', 0), 0),
             new TextNode(' apples', 0),
         ]);
         $node = new TransNode($body, $plural, $count, $context, null, $domain, 0);
@@ -258,8 +235,8 @@ class MoTranslatorTransTest extends NodeTestCase
                 . ' strtr(_dnpgettext("mydomain", "The context", "Hey %%name%%, I have one apple",'
                 . ' "Hey %%name%%, I have %%count%% apples", abs(12)), array("%%name%%" => %s,'
                 . ' "%%name%%" => %s, "%%count%%" => abs(12), ));',
-                $this->getVariableGetter('name'),
-                $this->getVariableGetter('name')
+                self::createVariableGetter('name'),
+                self::createVariableGetter('name')
             ),
         ];
 

--- a/test/Node/TransTest.php
+++ b/test/Node/TransTest.php
@@ -14,36 +14,31 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Twig\Extensions\Node;
 
+use PhpMyAdmin\Tests\Twig\Extensions\NodeTestCase;
 use PhpMyAdmin\Twig\Extensions\Node\TransNode;
-use Twig\Attribute\YieldReady;
 use Twig\Environment;
 use Twig\Node\CheckToStringNode;
 use Twig\Node\Expression\ConstantExpression;
 use Twig\Node\Expression\FilterExpression;
-use Twig\Node\Expression\NameExpression;
 use Twig\Node\PrintNode;
 use Twig\Node\TextNode;
-use Twig\Test\NodeTestCase;
+use Twig\TwigFilter;
 
-use function class_exists;
 use function sprintf;
 use function version_compare;
 
-class TransTest extends NodeTestCase
+final class TransTest extends NodeTestCase
 {
-    private static function echoOrYield(): string
-    {
-        return class_exists(YieldReady::class) ? 'yield' : 'echo';
-    }
-
-    /**
-     * Twig 3.26 encodes single quotes as \x27 (not ') in compiled string literals
-     * as a defense-in-depth measure, so the expected output differs by Twig version.
-     */
-    private static function apostrophe(): string
+    /** @return ConstantExpression */
+    public static function getFilter(string $filterName, int $lineno)
     {
         /** @phpstan-ignore-next-line */
-        return version_compare(Environment::VERSION, '3.26.0', '>=') ? '\\x27' : '\'';
+        if (version_compare(Environment::VERSION, '3.12.0', '>=')) {
+            /** @phpstan-ignore-next-line */
+            return new TwigFilter($filterName);
+        }
+
+        return new ConstantExpression($filterName, $lineno);
     }
 
     public function testConstructor(): void
@@ -54,16 +49,16 @@ class TransTest extends NodeTestCase
         ]);
         $plural = new Nodes([
             new TextNode('Hey ', 0),
-            new PrintNode(new NameExpression('name', 0), 0),
+            new PrintNode(self::createContextVariable('name', 0), 0),
             new TextNode(', I have ', 0),
-            new PrintNode(new NameExpression('count', 0), 0),
+            new PrintNode(self::createContextVariable('count', 0), 0),
             new TextNode(' apples', 0),
         ]);
         $node = new TransNode($body, $plural, $count, null, null, null, 0);
 
-        $this->assertEquals($body, $node->getNode('body'));
-        $this->assertEquals($count, $node->getNode('count'));
-        $this->assertEquals($plural, $node->getNode('plural'));
+        self::assertEquals($body, $node->getNode('body'));
+        self::assertEquals($count, $node->getNode('count'));
+        self::assertEquals($plural, $node->getNode('plural'));
     }
 
     public function testConstructorWithDomain(): void
@@ -77,17 +72,17 @@ class TransTest extends NodeTestCase
         ]);
         $plural = new Nodes([
             new TextNode('Hey ', 0),
-            new PrintNode(new NameExpression('name', 0), 0),
+            new PrintNode(self::createContextVariable('name', 0), 0),
             new TextNode(', I have ', 0),
-            new PrintNode(new NameExpression('count', 0), 0),
+            new PrintNode(self::createContextVariable('count', 0), 0),
             new TextNode(' apples', 0),
         ]);
         $node = new TransNode($body, $plural, $count, null, null, $domain, 0);
 
-        $this->assertEquals($body, $node->getNode('body'));
-        $this->assertEquals($count, $node->getNode('count'));
-        $this->assertEquals($plural, $node->getNode('plural'));
-        $this->assertEquals($domain, $node->getNode('domain'));
+        self::assertEquals($body, $node->getNode('body'));
+        self::assertEquals($count, $node->getNode('count'));
+        self::assertEquals($plural, $node->getNode('plural'));
+        self::assertEquals($domain, $node->getNode('domain'));
     }
 
     public function testEnableDebugNotEnabled(): void
@@ -96,7 +91,7 @@ class TransTest extends NodeTestCase
         $body = new TextNode('There is 1 pending task', 0);
         $plural = new Nodes([
             new TextNode('There are ', 0),
-            new PrintNode(new NameExpression('count', 0), 0),
+            new PrintNode(self::createContextVariable('count', 0), 0),
             new TextNode(' pending tasks', 0),
         ]);
         $notes = new TextNode('Notes for translators', 0);
@@ -105,15 +100,15 @@ class TransTest extends NodeTestCase
         $node = new TransNode($body, $plural, $count, null, $notes, null, 80);
 
         $compiler = $this->getCompiler();
-        $this->assertEmpty($compiler->getDebugInfo());
+        self::assertEmpty($compiler->getDebugInfo());
         $sourceCode = $compiler->compile($node)->getSource();
-        $this->assertSame(
+        self::assertSame(
             '// custom: Notes for translators' . "\n"
             . self::echoOrYield() . ' strtr(ngettext("There is 1 pending task",'
             . ' "There are %count% pending tasks", abs(5)), array("%count%" => abs(5), ));' . "\n",
             $sourceCode
         );
-        $this->assertSame([], $compiler->getDebugInfo());
+        self::assertSame([], $compiler->getDebugInfo());
         TransNode::$enableAddDebugInfo = false;
         TransNode::$notesLabel = '// notes: ';
     }
@@ -124,7 +119,7 @@ class TransTest extends NodeTestCase
         $body = new TextNode('There is 1 pending task', 0);
         $plural = new Nodes([
             new TextNode('There are ', 0),
-            new PrintNode(new NameExpression('count', 0), 0),
+            new PrintNode(self::createContextVariable('count', 0), 0),
             new TextNode(' pending tasks', 0),
         ]);
         $notes = new TextNode('Notes for translators', 0);
@@ -134,39 +129,36 @@ class TransTest extends NodeTestCase
         $node = new TransNode($body, $plural, $count, null, $notes, null, 80);
 
         $compiler = $this->getCompiler();
-        $this->assertEmpty($compiler->getDebugInfo());
+        self::assertEmpty($compiler->getDebugInfo());
         $sourceCode = $compiler->compile($node)->getSource();
-        $this->assertSame(
+        self::assertSame(
             '// line 80' . "\n" . '// custom: Notes for translators' . "\n"
             . self::echoOrYield() . ' strtr(ngettext("There'
             . ' is 1 pending task", "There are %count% pending tasks", abs(5)), array("%count%" => abs(5), ));' . "\n",
             $sourceCode
         );
-        $this->assertSame([2 => 80], $compiler->getDebugInfo());
+        self::assertSame([2 => 80], $compiler->getDebugInfo());
         TransNode::$enableAddDebugInfo = false;
         TransNode::$notesLabel = '// notes: ';
     }
 
-    /**
-     * @return array[]
-     */
-    public function getTests(): array
+    public static function provideTests(): iterable
     {
         $tests = [];
 
-        $body = new NameExpression('foo', 0);
+        $body = self::createContextVariable('foo', 0);
         $domain = new Nodes([
             new TextNode('coredomain', 0),
         ]);
         $node = new TransNode($body, null, null, null, null, $domain, 0);
         $tests[] = [
             $node,
-            sprintf(self::echoOrYield() . ' dgettext("coredomain", %s);', $this->getVariableGetter('foo')),
+            sprintf(self::echoOrYield() . ' dgettext("coredomain", %s);', self::createVariableGetter('foo')),
         ];
 
-        $body = new NameExpression('foo', 0);
+        $body = self::createContextVariable('foo', 0);
         $node = new TransNode($body, null, null, null, null, null, 0);
-        $tests[] = [$node, sprintf(self::echoOrYield() . ' gettext(%s);', $this->getVariableGetter('foo'))];
+        $tests[] = [$node, sprintf(self::echoOrYield() . ' gettext(%s);', self::createVariableGetter('foo'))];
 
         $body = new ConstantExpression('Hello', 0);
         $node = new TransNode($body, null, null, null, null, null, 0);
@@ -180,7 +172,7 @@ class TransTest extends NodeTestCase
 
         $body = new Nodes([
             new TextNode('J\'ai ', 0),
-            new PrintNode(new NameExpression('foo', 0), 0),
+            new PrintNode(self::createContextVariable('foo', 0), 0),
             new TextNode(' pommes', 0),
         ]);
         $node = new TransNode($body, null, null, null, null, null, 0);
@@ -189,21 +181,21 @@ class TransTest extends NodeTestCase
             sprintf(
                 self::echoOrYield() . ' strtr(gettext("J' . self::apostrophe()
                     . 'ai %%foo%% pommes"), array("%%foo%%" => %s, ));',
-                $this->getVariableGetter('foo')
+                self::createVariableGetter('foo')
             ),
         ];
 
         $count = new ConstantExpression(12, 0);
         $body = new Nodes([
             new TextNode('Hey ', 0),
-            new PrintNode(new NameExpression('name', 0), 0),
+            new PrintNode(self::createContextVariable('name', 0), 0),
             new TextNode(', I have one apple', 0),
         ]);
         $plural = new Nodes([
             new TextNode('Hey ', 0),
-            new PrintNode(new NameExpression('name', 0), 0),
+            new PrintNode(self::createContextVariable('name', 0), 0),
             new TextNode(', I have ', 0),
-            new PrintNode(new NameExpression('count', 0), 0),
+            new PrintNode(self::createContextVariable('count', 0), 0),
             new TextNode(' apples', 0),
         ]);
         $node = new TransNode($body, $plural, $count, null, null, null, 0);
@@ -213,8 +205,8 @@ class TransTest extends NodeTestCase
                 self::echoOrYield() . ' strtr(ngettext("Hey %%name%%, I have one apple", "Hey %%name%%, I have'
                 . ' %%count%% apples", abs(12)), array("%%name%%" => %s,'
                 . ' "%%name%%" => %s, "%%count%%" => abs(12), ));',
-                $this->getVariableGetter('name'),
-                $this->getVariableGetter('name')
+                self::createVariableGetter('name'),
+                self::createVariableGetter('name')
             ),
         ];
 
@@ -222,7 +214,12 @@ class TransTest extends NodeTestCase
         $body = new Nodes([
             new TextNode('J\'ai ', 0),
             new PrintNode(
-                new FilterExpression(new NameExpression('foo', 0), new ConstantExpression('escape', 0), new Nodes(), 0),
+                new FilterExpression(
+                    self::createContextVariable('foo', 0),
+                    self::getFilter('escape', 0),
+                    new Nodes(),
+                    0
+                ),
                 0
             ),
             new TextNode(' pommes', 0),
@@ -234,7 +231,7 @@ class TransTest extends NodeTestCase
             sprintf(
                 self::echoOrYield() . ' strtr(gettext("J' . self::apostrophe()
                     . 'ai %%foo%% pommes"), array("%%foo%%" => %s, ));',
-                $this->getVariableGetter('foo')
+                self::createVariableGetter('foo')
             ),
         ];
 
@@ -245,8 +242,8 @@ class TransTest extends NodeTestCase
             new PrintNode(
                 new CheckToStringNode(
                     new FilterExpression(
-                        new NameExpression('foo', 0),
-                        new ConstantExpression('escape', 0),
+                        self::createContextVariable('foo', 0),
+                        self::getFilter('escape', 0),
                         new Nodes(),
                         0
                     )
@@ -262,7 +259,7 @@ class TransTest extends NodeTestCase
             sprintf(
                 self::echoOrYield() . ' strtr(gettext("J' . self::apostrophe()
                     . 'ai %%foo%% pommes"), array("%%foo%%" => %s, ));',
-                $this->getVariableGetter('foo')
+                self::createVariableGetter('foo')
             ),
         ];
 
@@ -274,12 +271,12 @@ class TransTest extends NodeTestCase
                 new CheckToStringNode(
                     new FilterExpression(
                         new FilterExpression(
-                            new NameExpression('foo', 0),
-                            new ConstantExpression('upper', 0),
+                            self::createContextVariable('foo', 0),
+                            self::getFilter('upper', 0),
                             new Nodes(),
                             0
                         ),
-                        new ConstantExpression('escape', 0),
+                        self::getFilter('escape', 0),
                         new Nodes(),
                         0
                     )
@@ -295,7 +292,7 @@ class TransTest extends NodeTestCase
             sprintf(
                 self::echoOrYield() . ' strtr(gettext("J' . self::apostrophe()
                     . 'ai %%foo%% pommes"), array("%%foo%%" => %s, ));',
-                $this->getVariableGetter('foo')
+                self::createVariableGetter('foo')
             ),
         ];
 
@@ -318,7 +315,7 @@ class TransTest extends NodeTestCase
         $body = new TextNode('There is 1 pending task', 0);
         $plural = new Nodes([
             new TextNode('There are ', 0),
-            new PrintNode(new NameExpression('count', 0), 0),
+            new PrintNode(self::createContextVariable('count', 0), 0),
             new TextNode(' pending tasks', 0),
         ]);
         $notes = new TextNode('Notes for translators', 0);

--- a/test/NodeTestCase.php
+++ b/test/NodeTestCase.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpMyAdmin\Tests\Twig\Extensions;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Twig\Attribute\YieldReady;
+use Twig\Compiler;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+use Twig\Node\Expression\NameExpression;
+use Twig\Node\Expression\Variable\ContextVariable;
+use Twig\Node\Node;
+
+use function class_exists;
+use function sprintf;
+use function trim;
+use function version_compare;
+
+// phpcs:disable SlevomatCodingStandard.Namespaces.UnusedUses.MismatchingCaseSensitivity
+
+abstract class NodeTestCase extends TestCase
+{
+    /** @var Environment|null */
+    private $currentEnv = null;
+
+    protected static function echoOrYield(): string
+    {
+        return class_exists(YieldReady::class) ? 'yield' : 'echo';
+    }
+
+    /**
+     * Twig 3.26 encodes single quotes as \x27 (not ') in compiled string literals
+     * as a defense-in-depth measure, so the expected output differs by Twig version.
+     */
+    protected static function apostrophe(): string
+    {
+        /** @phpstan-ignore-next-line */
+        return version_compare(Environment::VERSION, '3.26.0', '>=') ? '\\x27' : '\'';
+    }
+
+    protected static function createContextVariable(string $name, int $lineno): NameExpression
+    {
+        if (class_exists(ContextVariable::class)) {
+            /** @phpstan-ignore-next-line */
+            return new ContextVariable($name, $lineno);
+        }
+
+        return new NameExpression($name, $lineno);
+    }
+
+    /**
+     * @return iterable<array{0: Node, 1: string, 2?: Environment|null, 3?: bool}>
+     */
+    abstract public static function provideTests(): iterable;
+
+    /** @dataProvider provideTests */
+    #[DataProvider('provideTests')]
+    public function testCompile(
+        Node $node,
+        string $source,
+        ?Environment $environment = null,
+        bool $isPattern = false
+    ): void {
+        $this->assertNodeCompilation($source, $node, $environment, $isPattern);
+    }
+
+    public function assertNodeCompilation(
+        string $source,
+        Node $node,
+        ?Environment $environment = null,
+        bool $isPattern = false
+    ): void {
+        $compiler = $this->getCompiler($environment);
+        $compiler->compile($node);
+
+        if ($isPattern) {
+            self::assertStringMatchesFormat($source, trim($compiler->getSource()));
+        } else {
+            self::assertEquals($source, trim($compiler->getSource()));
+        }
+    }
+
+    protected function getCompiler(?Environment $environment = null): Compiler
+    {
+        return new Compiler($environment ?? $this->getEnvironment());
+    }
+
+    final protected function getEnvironment(): Environment
+    {
+        $this->currentEnv = $this->currentEnv ?? static::createEnvironment();
+
+        return $this->currentEnv;
+    }
+
+    protected static function createEnvironment(): Environment
+    {
+        return new Environment(new ArrayLoader());
+    }
+
+    final protected static function createVariableGetter(string $name, bool $line = false): string
+    {
+        $line = $line > 0 ? '// line ' . $line . "\n" : '';
+
+        return sprintf('%s($context["%s"] ?? null)', $line, $name);
+    }
+
+    final protected static function createAttributeGetter(): string
+    {
+        return 'CoreExtension::getAttribute($this->env, $this->source, ';
+    }
+}


### PR DESCRIPTION
Forks `Twig\Test\NodeTestCase` and `Twig\Test\IntegrationTestCase` from Twig to `PhpMyAdmin\Tests\Twig\Extensions\NodeTestCase` and `PhpMyAdmin\Tests\Twig\Extensions\IntegrationTestCase` respectively to be able to add support for newer versions of PHPUnit.