### PR TITLE
Bump codecov/codecov-action to v7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
         run: composer run phpunit
 
       - name: Send coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v7
         with:
           flags: unit-${{ matrix.php-version }}
           name: phpunit-${{ matrix.php-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,3 +44,4 @@ jobs:
         with:
           flags: unit-${{ matrix.php-version }}
           name: phpunit-${{ matrix.php-version }}
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/src/TokenParser/TransTokenParser.php
+++ b/src/TokenParser/TransTokenParser.php
@@ -114,17 +114,13 @@ class TransTokenParser extends AbstractTokenParser
         return [$body, $plural, $count, $context, $notes, $domain, $lineno, $this->getTag()];
     }
 
-    /**
-     * @return bool
-     */
+    /** @return bool */
     public function decideForFork(Token $token)
     {
         return $token->test(['plural', 'context', 'notes', 'endtrans']);
     }
 
-    /**
-     * @return bool
-     */
+    /** @return bool */
     public function decideForEnd(Token $token)
     {
         return $token->test('endtrans');

--- a/test/I18nExtensionMoTranslatorDebugTest.php
+++ b/test/I18nExtensionMoTranslatorDebugTest.php
@@ -24,9 +24,7 @@ class I18nExtensionMoTranslatorDebugTest extends IntegrationTestCase
         Loader::loadFunctions();
     }
 
-    /**
-     * @return AbstractExtension[]
-     */
+    /** @return AbstractExtension[] */
     public function getExtensions()
     {
         return [
@@ -34,9 +32,7 @@ class I18nExtensionMoTranslatorDebugTest extends IntegrationTestCase
         ];
     }
 
-    /**
-     * @return string
-     */
+    /** @return string */
     public function getFixturesDir()
     {
         return __DIR__ . '/Fixtures/';

--- a/test/I18nExtensionMoTranslatorSandboxTest.php
+++ b/test/I18nExtensionMoTranslatorSandboxTest.php
@@ -25,9 +25,7 @@ class I18nExtensionMoTranslatorSandboxTest extends IntegrationTestCase
         Loader::loadFunctions();
     }
 
-    /**
-     * @return AbstractExtension[]
-     */
+    /** @return AbstractExtension[] */
     public function getExtensions()
     {
         $tags = ['if', 'set', 'trans'];
@@ -43,9 +41,7 @@ class I18nExtensionMoTranslatorSandboxTest extends IntegrationTestCase
         ];
     }
 
-    /**
-     * @return string
-     */
+    /** @return string */
     public function getFixturesDir()
     {
         return __DIR__ . '/FixturesWithSandbox/';

--- a/test/I18nExtensionMoTranslatorTest.php
+++ b/test/I18nExtensionMoTranslatorTest.php
@@ -23,9 +23,7 @@ class I18nExtensionMoTranslatorTest extends IntegrationTestCase
         Loader::loadFunctions();
     }
 
-    /**
-     * @return AbstractExtension[]
-     */
+    /** @return AbstractExtension[] */
     public function getExtensions()
     {
         return [
@@ -33,9 +31,7 @@ class I18nExtensionMoTranslatorTest extends IntegrationTestCase
         ];
     }
 
-    /**
-     * @return string
-     */
+    /** @return string */
     public function getFixturesDir()
     {
         return __DIR__ . '/Fixtures/';

--- a/test/I18nExtensionSandboxTest.php
+++ b/test/I18nExtensionSandboxTest.php
@@ -19,9 +19,7 @@ use Twig\Test\IntegrationTestCase;
 
 class I18nExtensionSandboxTest extends IntegrationTestCase
 {
-    /**
-     * @return AbstractExtension[]
-     */
+    /** @return AbstractExtension[] */
     public function getExtensions()
     {
         $tags = ['if', 'set', 'trans'];
@@ -37,9 +35,7 @@ class I18nExtensionSandboxTest extends IntegrationTestCase
         ];
     }
 
-    /**
-     * @return string
-     */
+    /** @return string */
     public function getFixturesDir()
     {
         return __DIR__ . '/FixturesWithSandbox/';

--- a/test/I18nExtensionTest.php
+++ b/test/I18nExtensionTest.php
@@ -17,9 +17,7 @@ use Twig\Test\IntegrationTestCase;
 
 class I18nExtensionTest extends IntegrationTestCase
 {
-    /**
-     * @return AbstractExtension[]
-     */
+    /** @return AbstractExtension[] */
     public function getExtensions()
     {
         return [
@@ -27,9 +25,7 @@ class I18nExtensionTest extends IntegrationTestCase
         ];
     }
 
-    /**
-     * @return string
-     */
+    /** @return string */
     public function getFixturesDir()
     {
         return __DIR__ . '/Fixtures/';

--- a/test/Node/MoTranslatorTransTest.php
+++ b/test/Node/MoTranslatorTransTest.php
@@ -88,9 +88,7 @@ class MoTranslatorTransTest extends NodeTestCase
         $this->assertEquals($context, $node->getNode('context'));
     }
 
-    /**
-     * @return array[]
-     */
+    /** @return array[] */
     public function getTests(): array
     {
         $tests = [];

--- a/test/Node/TransTest.php
+++ b/test/Node/TransTest.php
@@ -147,9 +147,7 @@ class TransTest extends NodeTestCase
         TransNode::$notesLabel = '// notes: ';
     }
 
-    /**
-     * @return array[]
-     */
+    /** @return array[] */
     public function getTests(): array
     {
         $tests = [];


### PR DESCRIPTION
This should fix:

https://github.com/phpmyadmin/twig-i18n-extension/actions/runs/28813049880/job/85445526554

```
Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
Run codecov/codecov-action@v3
==> linux OS detected
(node:2973) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
==> SHASUM file signed by key id 806bb28aed779869
==> Uploader SHASUM verified (b37359013b48fbc3b0790d59fc474a52a260fb96e28e1b2c2ae001dc9b9cc996  codecov)
==> Running version latest
==> Running version v0.8.0
/home/runner/work/_actions/codecov/codecov-action/v3/dist/codecov -n phpunit-8.6 -Q github-action-3.1.6 -F unit-8.6 -C b95a364f46592be0e0958b4ee30d2ea9b2a328b1
[2026-07-06T18:11:40.509Z] ['info'] 
     _____          _
    / ____|        | |
   | |     ___   __| | ___  ___ _____   __
   | |    / _ \ / _` |/ _ \/ __/ _ \ \ / /
   | |___| (_) | (_| |  __/ (_| (_) \ V /
    \_____\___/ \__,_|\___|\___\___/ \_/

  Codecov report uploader 0.8.0
[2026-07-06T18:11:40.516Z] ['info'] => Project root located at: /home/runner/work/twig-i18n-extension/twig-i18n-extension
[2026-07-06T18:11:40.517Z] ['info'] -> No token specified or token is empty
[2026-07-06T18:11:40.523Z] ['info'] Searching for coverage files...
[2026-07-06T18:11:40.574Z] ['info'] Warning: Some files located via search were excluded from upload.
[2026-07-06T18:11:40.575Z] ['info'] If Codecov did not locate your files, please review https://docs.codecov.com/docs/supported-report-formats
[2026-07-06T18:11:40.575Z] ['info'] => Found 1 possible coverage files:
  build/logs/clover.xml
[2026-07-06T18:11:40.575Z] ['info'] Processing /home/runner/work/twig-i18n-extension/twig-i18n-extension/build/logs/clover.xml...
[2026-07-06T18:11:40.578Z] ['info'] Detected GitHub Actions as the CI provider.
[2026-07-06T18:11:41.106Z] ['info'] Pinging Codecov: https://codecov.io/upload/v4?package=github-action-3.1.6-uploader-0.8.0&token=*******&branch=php8.6&build=28813049880&build_url=https%3A%2F%2Fgithub.com%2Fphpmyadmin%2Ftwig-i18n-extension%2Factions%2Fruns%2F28813049880&commit=b95a364f46592be0e0958b4ee30d2ea9b2a328b1&job=Run+tests&pr=28&service=github-actions&slug=phpmyadmin%2Ftwig-i18n-extension&name=phpunit-8.6&tag=&flags=unit-8.6&parent=
[2026-07-06T18:11:41.370Z] ['error'] There was an error running the uploader: Error uploading to [https://codecov.io:](https://codecov.io/) Error: There was an error fetching the storage URL during POST: 429 - {"message":"Rate limit reached. Please upload with the Codecov repository upload token to resolve issue. Expected time to availability: 3366s."}

[2026-07-06T18:11:41.371Z] ['info'] Codecov will exit with status code 0. If you are expecting a non-zero exit code, please pass in the `-Z` flag
```

Also, `CODECOV_TOKEN` should be added. See https://docs.codecov.com/docs/adding-the-codecov-token